### PR TITLE
Disabled call to apparent debugging function

### DIFF
--- a/src/main/java/gate/creole/GazetteerListsCollector.java
+++ b/src/main/java/gate/creole/GazetteerListsCollector.java
@@ -74,7 +74,7 @@ public class GazetteerListsCollector extends AbstractLanguageAnalyser {
     }
 
     // print out the stats in log files
-    printStats();
+    //printStats();
 
     // save the updated gazetteer lists now
     Map<LinearNode, GazetteerList> theLists =


### PR DESCRIPTION
Disabled call to apparent debugging function that fails on systems where the GATE home directory is not writeable, such as Win10. It attempts to write to the current directory, causing an access-denied error.